### PR TITLE
the penultimate exception is thrown instead of the last one

### DIFF
--- a/src/retry/src/Aeon/Retry/Retry.php
+++ b/src/retry/src/Aeon/Retry/Retry.php
@@ -85,21 +85,15 @@ final class Retry
         $exceptions = [];
 
         if ($this->retries === 0) {
-            try {
-                $lastReturn = $function($this->lastExecution = new Execution(0));
+            $lastReturn = $function($this->lastExecution = new Execution(0));
 
-                $terminationException = $this->lastExecution->terminationException();
+            $terminationException = $this->lastExecution->terminationException();
 
-                if ($terminationException) {
-                    throw $terminationException;
-                }
-
-                return $lastReturn;
-            } catch (\Throwable $throwable) {
-                $exceptions[] = $throwable;
-
-                throw $throwable;
+            if ($terminationException) {
+                throw $terminationException;
             }
+
+            return $lastReturn;
         }
 
         for ($retry = 0; $retry < $this->retries; $retry++) {
@@ -130,12 +124,9 @@ final class Retry
             $this->wait();
         }
 
-        if ($this->lastExecution) {
-            $lastException = $this->lastExecution()->lasException();
-
-            if ($lastException instanceof \Throwable) {
-                throw $lastException;
-            }
+        $lastException = end($exceptions);
+        if ($lastException instanceof \Throwable) {
+            throw $lastException;
         }
 
         throw new RetryException(\sprintf('Retry failed to execute function and return value in %d attempts', $this->retries));

--- a/src/retry/src/Aeon/Retry/Retry.php
+++ b/src/retry/src/Aeon/Retry/Retry.php
@@ -124,7 +124,8 @@ final class Retry
             $this->wait();
         }
 
-        $lastException = end($exceptions);
+        $lastException = \end($exceptions);
+
         if ($lastException instanceof \Throwable) {
             throw $lastException;
         }

--- a/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
+++ b/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
@@ -218,8 +218,8 @@ final class RetryTest extends TestCase
             new \RuntimeException('fifth'),
         ];
 
-        $callable = function () use (&$queue) {
-            throw array_shift($queue);
+        $callable = function () use (&$queue) : void {
+            throw \array_shift($queue);
         };
 
         (new Retry(

--- a/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
+++ b/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
@@ -206,4 +206,27 @@ final class RetryTest extends TestCase
         ))->modifyDelay(new ConstantDelay())
             ->lastExecution();
     }
+
+    public function test_throws_the_last_exception() : void
+    {
+        $this->expectExceptionMessage('fifth');
+        $queue = [
+            new \RuntimeException('first'),
+            new \RuntimeException('second'),
+            new \RuntimeException('third'),
+            new \RuntimeException('fourth'),
+            new \RuntimeException('fifth'),
+        ];
+
+        $callable = function () use (&$queue) {
+            throw array_shift($queue);
+        };
+
+        (new Retry(
+            new DummyProcess(),
+            5,
+            TimeUnit::seconds(3)
+        ))->modifyDelay(new ConstantDelay())
+            ->execute($callable);
+    }
 }


### PR DESCRIPTION
# Description

When a series of different exceptions is thrown, the last one is expected to be thrown from the `Retry::execute()` call

Actually, the second-to-last one is thrown.

<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>The correct exception is thrown if multiple ones occur during execution</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>
