### PR TITLE
retry waits needlessly after the last execution

### DIFF
--- a/src/retry/src/Aeon/Retry/Retry.php
+++ b/src/retry/src/Aeon/Retry/Retry.php
@@ -127,7 +127,9 @@ final class Retry
                 }
             }
 
-            $this->wait();
+            if (false === $this->isLastRetry($retry)) {
+                $this->wait();
+            }
         }
 
         if ($this->lastExecution) {
@@ -153,5 +155,10 @@ final class Retry
         }
 
         return $this->lastExecution;
+    }
+
+    private function isLastRetry(int $retry) : bool
+    {
+        return $retry === $this->retries - 1;
     }
 }

--- a/src/retry/tests/Aeon/Retry/Tests/TestDouble/Process/SpyProcess.php
+++ b/src/retry/tests/Aeon/Retry/Tests/TestDouble/Process/SpyProcess.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aeon\Retry\Tests\TestDouble\Process;
+
+use Aeon\Calendar\TimeUnit;
+use Aeon\Sleep\Process;
+use Aeon\Sleep\SystemProcess;
+
+final class SpyProcess implements Process
+{
+    public array $calls = [];
+
+    public function sleep(TimeUnit $timeUnit) : void
+    {
+        $this->calls[] = $timeUnit;
+    }
+}

--- a/src/retry/tests/Aeon/Retry/Tests/TestDouble/Process/SpyProcess.php
+++ b/src/retry/tests/Aeon/Retry/Tests/TestDouble/Process/SpyProcess.php
@@ -1,10 +1,9 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Aeon\Retry\Tests\TestDouble\Process;
 
 use Aeon\Calendar\TimeUnit;
 use Aeon\Sleep\Process;
-use Aeon\Sleep\SystemProcess;
 
 final class SpyProcess implements Process
 {

--- a/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
+++ b/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
@@ -9,6 +9,7 @@ use Aeon\Retry\DelayModifier\ConstantDelay;
 use Aeon\Retry\Exception\RetryException;
 use Aeon\Retry\Execution;
 use Aeon\Retry\Retry;
+use Aeon\Retry\Tests\TestDouble\Process\SpyProcess;
 use Aeon\Sleep\DummyProcess;
 use PHPUnit\Framework\TestCase;
 
@@ -192,6 +193,24 @@ final class RetryTest extends TestCase
 
         $this->assertCount(1, $retry->lastExecution()->exceptions());
         $this->assertSame(1, $retry->lastExecution()->retry());
+    }
+
+    public function test_process_waits_only_between_the_executions() : void
+    {
+        $calls = 0;
+        $callable = function () use (&$calls) {
+            $calls++;
+            throw new \RuntimeException('bork!');
+        };
+        $spy = new SpyProcess();
+
+        try {
+            (new Retry($spy, 5, TimeUnit::seconds(3)))->execute($callable);
+        } catch (\Throwable) {
+            // discard
+        }
+
+        $this->assertCount($calls - 1, $spy->calls, 'Expected to sleep only between calls');
     }
 
     public function test_last_execution_when_not_executed() : void

--- a/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
+++ b/src/retry/tests/Aeon/Retry/Tests/Unit/RetryTest.php
@@ -198,8 +198,9 @@ final class RetryTest extends TestCase
     public function test_process_waits_only_between_the_executions() : void
     {
         $calls = 0;
-        $callable = function () use (&$calls) {
+        $callable = function () use (&$calls) : void {
             $calls++;
+
             throw new \RuntimeException('bork!');
         };
         $spy = new SpyProcess();


### PR DESCRIPTION
<h2>Description</h2>

Given the callable constantly fails.

Expected: the wait is called only between executions:

```
{exec 1} [wait] {exec 2} [wait] {exec 3}
```

Actual: it is additionally called one more time at the end, slowing down the process


```diff
-{exec 1} [wait] {exec 2} [wait] {exec 3}
+{exec 1} [wait] {exec 2} [wait] {exec 3} [wait]
```

<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>retry waits needlessly after the last execution</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
  </ul>     
</div>
<hr/>
