### PR TITLE
Revert "Bump supported Symfony versions"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "azuyalabs/yasumi": "~2.0",
         "doctrine/dbal": "~2.6 || ~3.0",
         "psr/cache": "~1.0|~2.0|~3.0",
-        "symfony/config": "^5.4.21||^6.3||^7.0",
-        "symfony/dependency-injection": "^5.4.21||^6.3||^7.0",
-        "symfony/form": "^5.4.21||^6.3||^7.0",
-        "symfony/http-kernel": "^5.4.21||^6.3||^7.0",
+        "symfony/config": "~4.4.44||~5.4.21||~6.0",
+        "symfony/dependency-injection": "~4.4.49||~5.4.21||~6.0",
+        "symfony/form": "~4.4.48||~5.4.21||~6.0",
+        "symfony/http-kernel": "~4.4.50||~5.4.21||~6.0",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/validator": "^5.4.21||^6.3||^7.0",
+        "symfony/validator": "~4.4.48||~5.4.21||~6.0",
         "twig/twig": "~1.43||~2.10||~3"
     },
     "require-dev": {
@@ -32,11 +32,11 @@
         "flow-php/etl-adapter-http": "^0.1 || ^0.2",
         "google/apiclient": "^2.0",
         "phpbench/phpbench": "^1.2.6",
-        "symfony/browser-kit": "^6.4||^7.0",
-        "symfony/cache": "^6.4||^7.0",
-        "symfony/dom-crawler": "^6.4||^7.0",
-        "symfony/framework-bundle": "^6.4||^7.0",
-        "symfony/security-bundle": "^6.4||^7.0"
+        "symfony/browser-kit": "~4.4.44||~5.4.21||~6",
+        "symfony/cache": "~4.4.48||~5.1||~6.0",
+        "symfony/dom-crawler": "~4.4.45||~5.4.21||~6.0",
+        "symfony/framework-bundle": "~4.4.49||~5.4.21||~6.0",
+        "symfony/security-bundle": "~4.4.44||~5.4.21||~6.0"
     },
     "suggest": {
         "ext-bcmath": "Compare time units with high precision"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbbfacd304ef2b21dac746a4f1d62f50",
+    "content-hash": "b55025575775d1b6ca55e802f70b3603",
     "packages": [
         {
             "name": "azuyalabs/yasumi",
@@ -703,16 +703,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.1",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f88ff6428afbeb17cc648c8003bd608534750baf"
+                "reference": "1f30f545c4151f611148fc19e28d54d39e0a00bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f88ff6428afbeb17cc648c8003bd608534750baf",
-                "reference": "f88ff6428afbeb17cc648c8003bd608534750baf",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1f30f545c4151f611148fc19e28d54d39e0a00bc",
+                "reference": "1f30f545c4151f611148fc19e28d54d39e0a00bc",
                 "shasum": ""
             },
             "require": {
@@ -720,7 +720,7 @@
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.2.10|^7.0"
+                "symfony/var-exporter": "^6.2.10"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
@@ -734,9 +734,9 @@
                 "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^6.1|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/yaml": "^5.4|^6.0|^7.0"
+                "symfony/config": "^6.1",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -764,7 +764,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.1"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -780,7 +780,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T14:56:37+00:00"
+            "time": "2023-10-31T08:07:48+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -851,31 +851,30 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.4.0",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "c873490a1c97b3a0a4838afc36ff36c112d02788"
+                "reference": "1f69476b64fb47105c06beef757766c376b548c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c873490a1c97b3a0a4838afc36ff36c112d02788",
-                "reference": "c873490a1c97b3a0a4838afc36ff36c112d02788",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/1f69476b64fb47105c06beef757766c376b548c4",
+                "reference": "1f69476b64fb47105c06beef757766c376b548c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/var-dumper": "^5.4|^6.0"
             },
             "conflict": {
-                "symfony/deprecation-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4"
+                "symfony/deprecation-contracts": "<2.5"
             },
             "require-dev": {
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/serializer": "^5.4|^6.0|^7.0"
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0"
             },
             "bin": [
                 "Resources/bin/patch-type-declarations"
@@ -906,7 +905,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.4.0"
+                "source": "https://github.com/symfony/error-handler/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -922,7 +921,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-18T09:43:34+00:00"
+            "time": "2023-09-12T06:57:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1319,25 +1318,25 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.1",
+            "version": "v6.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "2953274c16a229b3933ef73a6898e18388e12e1b"
+                "reference": "8d8e7aa60593fd0a2e3c1cea08cc687314841b61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/2953274c16a229b3933ef73a6898e18388e12e1b",
-                "reference": "2953274c16a229b3933ef73a6898e18388e12e1b",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8d8e7aa60593fd0a2e3c1cea08cc687314841b61",
+                "reference": "8d8e7aa60593fd0a2e3c1cea08cc687314841b61",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/error-handler": "^6.3",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/http-foundation": "^6.3.4",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -1345,7 +1344,7 @@
                 "symfony/cache": "<5.4",
                 "symfony/config": "<6.1",
                 "symfony/console": "<5.4",
-                "symfony/dependency-injection": "<6.4",
+                "symfony/dependency-injection": "<6.3.4",
                 "symfony/doctrine-bridge": "<5.4",
                 "symfony/form": "<5.4",
                 "symfony/http-client": "<5.4",
@@ -1355,7 +1354,7 @@
                 "symfony/translation": "<5.4",
                 "symfony/translation-contracts": "<2.5",
                 "symfony/twig-bridge": "<5.4",
-                "symfony/validator": "<6.4",
+                "symfony/validator": "<5.4",
                 "symfony/var-dumper": "<6.3",
                 "twig/twig": "<2.13"
             },
@@ -1364,26 +1363,26 @@
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^5.4|^6.0|^7.0",
-                "symfony/clock": "^6.2|^7.0",
-                "symfony/config": "^6.1|^7.0",
-                "symfony/console": "^5.4|^6.0|^7.0",
-                "symfony/css-selector": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/dom-crawler": "^5.4|^6.0|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/browser-kit": "^5.4|^6.0",
+                "symfony/clock": "^6.2",
+                "symfony/config": "^6.1",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dependency-injection": "^6.3.4",
+                "symfony/dom-crawler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/property-access": "^5.4.5|^6.0.5|^7.0",
-                "symfony/routing": "^5.4|^6.0|^7.0",
-                "symfony/serializer": "^6.3|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/translation": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/property-access": "^5.4.5|^6.0.5",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/serializer": "^6.3",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^5.4|^6.0|^7.0",
-                "symfony/validator": "^6.4|^7.0",
-                "symfony/var-exporter": "^6.2|^7.0",
+                "symfony/uid": "^5.4|^6.0",
+                "symfony/validator": "^6.3",
+                "symfony/var-exporter": "^6.2",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "type": "library",
@@ -1412,7 +1411,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.1"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.3.10"
             },
             "funding": [
                 {
@@ -1428,7 +1427,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T17:02:02+00:00"
+            "time": "2023-12-01T16:57:27+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -2666,16 +2665,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.4.1",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "2d08ca6b9cc704dce525615d1e6d1788734f36d9"
+                "reference": "d6081c0316f0f5921f2010d1766925005a82ea3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/2d08ca6b9cc704dce525615d1e6d1788734f36d9",
-                "reference": "2d08ca6b9cc704dce525615d1e6d1788734f36d9",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/d6081c0316f0f5921f2010d1766925005a82ea3b",
+                "reference": "d6081c0316f0f5921f2010d1766925005a82ea3b",
                 "shasum": ""
             },
             "require": {
@@ -2721,7 +2720,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.4.1"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -2737,7 +2736,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-30T10:32:10+00:00"
+            "time": "2023-11-28T20:41:49+00:00"
         },
         {
             "name": "twig/twig",
@@ -2968,16 +2967,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.10.0",
+            "version": "v6.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff"
+                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/a49db6f0a5033aef5143295342f1c95521b075ff",
-                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5dbc8959427416b8ee09a100d7a8588c00fb2e26",
+                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26",
                 "shasum": ""
             },
             "require": {
@@ -3025,9 +3024,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.10.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.8.1"
             },
-            "time": "2023-12-01T16:26:39+00:00"
+            "time": "2023-07-14T18:33:00+00:00"
         },
         {
             "name": "flow-php/array-dot",
@@ -3258,16 +3257,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.327.0",
+            "version": "v0.315.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "51a11d4ff70dd9f60334525e71bf4cf592e6d282"
+                "reference": "9fe675be642888cded64be861891901f092ab72d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/51a11d4ff70dd9f60334525e71bf4cf592e6d282",
-                "reference": "51a11d4ff70dd9f60334525e71bf4cf592e6d282",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/9fe675be642888cded64be861891901f092ab72d",
+                "reference": "9fe675be642888cded64be861891901f092ab72d",
                 "shasum": ""
             },
             "require": {
@@ -3296,22 +3295,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.327.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.315.0"
             },
-            "time": "2023-12-11T00:52:16+00:00"
+            "time": "2023-09-10T01:10:37+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.33.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "682dc6c30bb509953c9e43bb0960d901582da00b"
+                "reference": "6028b072aa444d7edecbed603431322026704627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/682dc6c30bb509953c9e43bb0960d901582da00b",
-                "reference": "682dc6c30bb509953c9e43bb0960d901582da00b",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/6028b072aa444d7edecbed603431322026704627",
+                "reference": "6028b072aa444d7edecbed603431322026704627",
                 "shasum": ""
             },
             "require": {
@@ -3354,22 +3353,22 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/main/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.33.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.30.0"
             },
-            "time": "2023-11-30T15:49:27+00:00"
+            "time": "2023-09-07T19:13:44+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.8.1",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104"
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/41042bc7ab002487b876a0683fc8dce04ddce104",
-                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9",
                 "shasum": ""
             },
             "require": {
@@ -3384,11 +3383,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.36 || ^9.6.15",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -3466,7 +3465,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.8.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.0"
             },
             "funding": [
                 {
@@ -3482,28 +3481,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-03T20:35:24+00:00"
+            "time": "2023-08-27T10:20:53+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "bbff78d96034045e58e13dedd6ad91b5d1253223"
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/bbff78d96034045e58e13dedd6ad91b5d1253223",
-                "reference": "bbff78d96034045e58e13dedd6ad91b5d1253223",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
+                "bamarni/composer-bin-plugin": "^1.8.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
             },
             "type": "library",
             "extra": {
@@ -3549,7 +3548,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.2"
+                "source": "https://github.com/guzzle/promises/tree/2.0.1"
             },
             "funding": [
                 {
@@ -3565,20 +3564,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-03T20:19:20+00:00"
+            "time": "2023-08-03T15:11:55+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.6.2",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221"
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221",
-                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
                 "shasum": ""
             },
             "require": {
@@ -3592,9 +3591,9 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -3665,7 +3664,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.6.2"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
             },
             "funding": [
                 {
@@ -3681,20 +3680,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-03T20:05:35+00:00"
+            "time": "2023-08-27T10:13:57+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "3.23.0",
+            "version": "3.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "d4ad81e2b67396e33dc9d7e54ec74ccf73151dcc"
+                "reference": "a141d430414fcb8bf797a18716b09f759a385bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/d4ad81e2b67396e33dc9d7e54ec74ccf73151dcc",
-                "reference": "d4ad81e2b67396e33dc9d7e54ec74ccf73151dcc",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a141d430414fcb8bf797a18716b09f759a385bed",
+                "reference": "a141d430414fcb8bf797a18716b09f759a385bed",
                 "shasum": ""
             },
             "require": {
@@ -3703,8 +3702,6 @@
                 "php": "^8.0.2"
             },
             "conflict": {
-                "async-aws/core": "<1.19.0",
-                "async-aws/s3": "<1.14.0",
                 "aws/aws-sdk-php": "3.209.31 || 3.210.0",
                 "guzzlehttp/guzzle": "<7.0",
                 "guzzlehttp/ringphp": "<1.1.1",
@@ -3712,8 +3709,8 @@
                 "symfony/http-client": "<5.2"
             },
             "require-dev": {
-                "async-aws/s3": "^1.5 || ^2.0",
-                "async-aws/simple-s3": "^1.1 || ^2.0",
+                "async-aws/s3": "^1.5",
+                "async-aws/simple-s3": "^1.1",
                 "aws/aws-sdk-php": "^3.220.0",
                 "composer/semver": "^3.0",
                 "ext-fileinfo": "*",
@@ -3722,9 +3719,9 @@
                 "friendsofphp/php-cs-fixer": "^3.5",
                 "google/cloud-storage": "^1.23",
                 "microsoft/azure-storage-blob": "^1.1",
-                "phpseclib/phpseclib": "^3.0.34",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5.11|^10.0",
+                "phpseclib/phpseclib": "^3.0.14",
+                "phpstan/phpstan": "^0.12.26",
+                "phpunit/phpunit": "^9.5.11",
                 "sabre/dav": "^4.3.1"
             },
             "type": "library",
@@ -3759,7 +3756,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.23.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.15.1"
             },
             "funding": [
                 {
@@ -3771,20 +3768,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-04T10:16:17+00:00"
+            "time": "2023-05-04T09:04:26+00:00"
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.23.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
-                "reference": "5cf046ba5f059460e86a997c504dd781a39a109b"
+                "reference": "543f64c397fefdf9cfeac443ffb6beff602796b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/5cf046ba5f059460e86a997c504dd781a39a109b",
-                "reference": "5cf046ba5f059460e86a997c504dd781a39a109b",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/543f64c397fefdf9cfeac443ffb6beff602796b3",
+                "reference": "543f64c397fefdf9cfeac443ffb6beff602796b3",
                 "shasum": ""
             },
             "require": {
@@ -3819,7 +3816,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem-local/issues",
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.23.0"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.15.0"
             },
             "funding": [
                 {
@@ -3831,20 +3828,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-04T10:14:46+00:00"
+            "time": "2023-05-02T20:02:14+00:00"
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.14.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "b6a5854368533df0295c5761a0253656a2e52d9e"
+                "reference": "a6dfb1194a2946fcdc1f38219445234f65b35c96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/b6a5854368533df0295c5761a0253656a2e52d9e",
-                "reference": "b6a5854368533df0295c5761a0253656a2e52d9e",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/a6dfb1194a2946fcdc1f38219445234f65b35c96",
+                "reference": "a6dfb1194a2946fcdc1f38219445234f65b35c96",
                 "shasum": ""
             },
             "require": {
@@ -3875,7 +3872,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.14.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.13.0"
             },
             "funding": [
                 {
@@ -3887,7 +3884,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-17T14:13:20+00:00"
+            "time": "2023-08-05T12:09:49+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -3958,16 +3955,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.5.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448"
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c915e2634718dbc8a4a15c61b0e62e7a44e14448",
-                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
                 "shasum": ""
             },
             "require": {
@@ -4043,7 +4040,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.5.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
             },
             "funding": [
                 {
@@ -4055,7 +4052,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-27T15:32:31+00:00"
+            "time": "2023-06-21T08:46:11+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -4534,16 +4531,16 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.3",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
                 "shasum": ""
             },
             "require": {
@@ -4580,9 +4577,9 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client"
+                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
             },
-            "time": "2023-09-23T14:17:50+00:00"
+            "time": "2023-04-10T20:12:12+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -5093,22 +5090,21 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v6.4.0",
+            "version": "v6.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "48102bcc56b26d453c7f5e7f72829abc9df25a16"
+                "reference": "a74086d3db70d0f06ffd84480daa556248706e98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/48102bcc56b26d453c7f5e7f72829abc9df25a16",
-                "reference": "48102bcc56b26d453c7f5e7f72829abc9df25a16",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/a74086d3db70d0f06ffd84480daa556248706e98",
+                "reference": "a74086d3db70d0f06ffd84480daa556248706e98",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/clock": "^1.0",
-                "symfony/polyfill-php83": "^1.28"
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -5147,7 +5143,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v6.4.0"
+                "source": "https://github.com/symfony/clock/tree/v6.3.4"
             },
             "funding": [
                 {
@@ -5163,20 +5159,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-13T14:46:14+00:00"
+            "time": "2023-07-31T11:35:03+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.1",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a550a7c99daeedef3f9d23fb82e3531525ff11fd"
+                "reference": "cd9864b47c367450e14ab32f78fdbf98c44c26b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a550a7c99daeedef3f9d23fb82e3531525ff11fd",
-                "reference": "a550a7c99daeedef3f9d23fb82e3531525ff11fd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cd9864b47c367450e14ab32f78fdbf98c44c26b6",
+                "reference": "cd9864b47c367450e14ab32f78fdbf98c44c26b6",
                 "shasum": ""
             },
             "require": {
@@ -5241,7 +5237,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.1"
+                "source": "https://github.com/symfony/console/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -5257,7 +5253,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-30T10:54:28+00:00"
+            "time": "2023-11-20T16:41:16+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -5392,34 +5388,34 @@
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v6.4.1",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "ac22d760bf9ff4440a1b6c7caef34d38b44290aa"
+                "reference": "e88be137ea0652ee2caf2eacb21283820904be4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/ac22d760bf9ff4440a1b6c7caef34d38b44290aa",
-                "reference": "ac22d760bf9ff4440a1b6c7caef34d38b44290aa",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/e88be137ea0652ee2caf2eacb21283820904be4f",
+                "reference": "e88be137ea0652ee2caf2eacb21283820904be4f",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": ">=2.1",
                 "ext-xml": "*",
                 "php": ">=8.1",
-                "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/config": "^6.1|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/config": "^6.1",
+                "symfony/dependency-injection": "^6.3.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.1|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/filesystem": "^5.4|^6.0|^7.0",
-                "symfony/finder": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4",
+                "symfony/error-handler": "^6.1",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-foundation": "^6.3",
+                "symfony/http-kernel": "^6.3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/routing": "^6.4|^7.0"
+                "symfony/routing": "^5.4|^6.0"
             },
             "conflict": {
                 "doctrine/annotations": "<1.13.1",
@@ -5427,71 +5423,67 @@
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/asset": "<5.4",
-                "symfony/asset-mapper": "<6.4",
                 "symfony/clock": "<6.3",
                 "symfony/console": "<5.4",
-                "symfony/dom-crawler": "<6.4",
+                "symfony/dom-crawler": "<6.3",
                 "symfony/dotenv": "<5.4",
                 "symfony/form": "<5.4",
                 "symfony/http-client": "<6.3",
                 "symfony/lock": "<5.4",
                 "symfony/mailer": "<5.4",
                 "symfony/messenger": "<6.3",
-                "symfony/mime": "<6.4",
+                "symfony/mime": "<6.2",
                 "symfony/property-access": "<5.4",
                 "symfony/property-info": "<5.4",
-                "symfony/scheduler": "<6.4",
                 "symfony/security-core": "<5.4",
                 "symfony/security-csrf": "<5.4",
-                "symfony/serializer": "<6.4",
+                "symfony/serializer": "<6.3",
                 "symfony/stopwatch": "<5.4",
-                "symfony/translation": "<6.4",
+                "symfony/translation": "<6.2.8",
                 "symfony/twig-bridge": "<5.4",
                 "symfony/twig-bundle": "<5.4",
-                "symfony/validator": "<6.4",
-                "symfony/web-profiler-bundle": "<6.4",
-                "symfony/workflow": "<6.4"
+                "symfony/validator": "<6.3",
+                "symfony/web-profiler-bundle": "<5.4",
+                "symfony/workflow": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.13.1|^2",
                 "doctrine/persistence": "^1.3|^2|^3",
-                "dragonmantank/cron-expression": "^3.1",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "seld/jsonlint": "^1.10",
-                "symfony/asset": "^5.4|^6.0|^7.0",
-                "symfony/asset-mapper": "^6.4|^7.0",
-                "symfony/browser-kit": "^5.4|^6.0|^7.0",
-                "symfony/clock": "^6.2|^7.0",
-                "symfony/console": "^5.4.9|^6.0.9|^7.0",
-                "symfony/css-selector": "^5.4|^6.0|^7.0",
-                "symfony/dom-crawler": "^6.4|^7.0",
-                "symfony/dotenv": "^5.4|^6.0|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/form": "^5.4|^6.0|^7.0",
-                "symfony/html-sanitizer": "^6.1|^7.0",
-                "symfony/http-client": "^6.3|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/mailer": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^6.3|^7.0",
-                "symfony/mime": "^6.4|^7.0",
-                "symfony/notifier": "^5.4|^6.0|^7.0",
+                "symfony/asset": "^5.4|^6.0",
+                "symfony/asset-mapper": "^6.3",
+                "symfony/browser-kit": "^5.4|^6.0",
+                "symfony/clock": "^6.2",
+                "symfony/console": "^5.4.9|^6.0.9",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dom-crawler": "^6.3",
+                "symfony/dotenv": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/html-sanitizer": "^6.1",
+                "symfony/http-client": "^6.3",
+                "symfony/lock": "^5.4|^6.0",
+                "symfony/mailer": "^5.4|^6.0",
+                "symfony/messenger": "^6.3",
+                "symfony/mime": "^6.2",
+                "symfony/notifier": "^5.4|^6.0",
                 "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/property-info": "^5.4|^6.0|^7.0",
-                "symfony/rate-limiter": "^5.4|^6.0|^7.0",
-                "symfony/scheduler": "^6.4|^7.0",
-                "symfony/security-bundle": "^5.4|^6.0|^7.0",
-                "symfony/semaphore": "^5.4|^6.0|^7.0",
-                "symfony/serializer": "^6.4|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/string": "^5.4|^6.0|^7.0",
-                "symfony/translation": "^6.4|^7.0",
-                "symfony/twig-bundle": "^5.4|^6.0|^7.0",
-                "symfony/uid": "^5.4|^6.0|^7.0",
-                "symfony/validator": "^6.4|^7.0",
-                "symfony/web-link": "^5.4|^6.0|^7.0",
-                "symfony/workflow": "^6.4|^7.0",
-                "symfony/yaml": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/scheduler": "^6.3",
+                "symfony/security-bundle": "^5.4|^6.0",
+                "symfony/semaphore": "^5.4|^6.0",
+                "symfony/serializer": "^6.3",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/string": "^5.4|^6.0",
+                "symfony/translation": "^6.2.8",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
+                "symfony/validator": "^6.3",
+                "symfony/web-link": "^5.4|^6.0",
+                "symfony/workflow": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0",
                 "twig/twig": "^2.10|^3.0"
             },
             "type": "symfony-bundle",
@@ -5520,7 +5512,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v6.4.1"
+                "source": "https://github.com/symfony/framework-bundle/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -5536,20 +5528,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:35:22+00:00"
+            "time": "2023-11-09T14:35:42+00:00"
         },
         {
             "name": "symfony/password-hasher",
-            "version": "v6.4.0",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/password-hasher.git",
-                "reference": "e001f752338a49d644ee0523fd7891aabaccb7e2"
+                "reference": "82161c4bebf77900372083ec6e484b5f055b0cba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/e001f752338a49d644ee0523fd7891aabaccb7e2",
-                "reference": "e001f752338a49d644ee0523fd7891aabaccb7e2",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/82161c4bebf77900372083ec6e484b5f055b0cba",
+                "reference": "82161c4bebf77900372083ec6e484b5f055b0cba",
                 "shasum": ""
             },
             "require": {
@@ -5559,8 +5551,8 @@
                 "symfony/security-core": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0",
-                "symfony/security-core": "^5.4|^6.0|^7.0"
+                "symfony/console": "^5.4|^6.0",
+                "symfony/security-core": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -5592,7 +5584,7 @@
                 "password"
             ],
             "support": {
-                "source": "https://github.com/symfony/password-hasher/tree/v6.4.0"
+                "source": "https://github.com/symfony/password-hasher/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -5608,7 +5600,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-06T11:00:25+00:00"
+            "time": "2023-11-06T10:58:05+00:00"
         },
         {
             "name": "symfony/process",
@@ -5673,16 +5665,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.1",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "0c95c164fdba18b12523b75e64199ca3503e6d40"
+                "reference": "82616e59acd3e3d9c916bba798326cb7796d7d31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/0c95c164fdba18b12523b75e64199ca3503e6d40",
-                "reference": "0c95c164fdba18b12523b75e64199ca3503e6d40",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/82616e59acd3e3d9c916bba798326cb7796d7d31",
+                "reference": "82616e59acd3e3d9c916bba798326cb7796d7d31",
                 "shasum": ""
             },
             "require": {
@@ -5698,11 +5690,11 @@
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.2|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^5.4|^6.0|^7.0",
-                "symfony/yaml": "^5.4|^6.0|^7.0"
+                "symfony/config": "^6.2",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -5736,7 +5728,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.1"
+                "source": "https://github.com/symfony/routing/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -5752,68 +5744,67 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T14:54:37+00:00"
+            "time": "2023-09-20T16:05:51+00:00"
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v6.4.0",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "4fd31b7cb2a18f62c5a8588b82a44fd240b41a9e"
+                "reference": "57889ebb1ac3403d550c787c4fde127261abacb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/4fd31b7cb2a18f62c5a8588b82a44fd240b41a9e",
-                "reference": "4fd31b7cb2a18f62c5a8588b82a44fd240b41a9e",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/57889ebb1ac3403d550c787c4fde127261abacb6",
+                "reference": "57889ebb1ac3403d550c787c4fde127261abacb6",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": ">=2.1",
                 "ext-xml": "*",
                 "php": ">=8.1",
-                "symfony/clock": "^6.3|^7.0",
-                "symfony/config": "^6.1|^7.0",
-                "symfony/dependency-injection": "^6.2|^7.0",
+                "symfony/clock": "^6.3",
+                "symfony/config": "^6.1",
+                "symfony/dependency-injection": "^6.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.2|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/http-foundation": "^6.2",
                 "symfony/http-kernel": "^6.2",
-                "symfony/password-hasher": "^5.4|^6.0|^7.0",
-                "symfony/security-core": "^6.2|^7.0",
-                "symfony/security-csrf": "^5.4|^6.0|^7.0",
-                "symfony/security-http": "^6.3.6|^7.0",
+                "symfony/password-hasher": "^5.4|^6.0",
+                "symfony/security-core": "^6.2",
+                "symfony/security-csrf": "^5.4|^6.0",
+                "symfony/security-http": "^6.3.6",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
                 "symfony/browser-kit": "<5.4",
                 "symfony/console": "<5.4",
-                "symfony/framework-bundle": "<6.4",
+                "symfony/framework-bundle": "<6.3",
                 "symfony/http-client": "<5.4",
                 "symfony/ldap": "<5.4",
-                "symfony/serializer": "<6.4",
-                "symfony/twig-bundle": "<5.4",
-                "symfony/validator": "<6.4"
+                "symfony/twig-bundle": "<5.4"
             },
             "require-dev": {
-                "symfony/asset": "^5.4|^6.0|^7.0",
-                "symfony/browser-kit": "^5.4|^6.0|^7.0",
-                "symfony/console": "^5.4|^6.0|^7.0",
-                "symfony/css-selector": "^5.4|^6.0|^7.0",
-                "symfony/dom-crawler": "^5.4|^6.0|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/form": "^5.4|^6.0|^7.0",
-                "symfony/framework-bundle": "^6.4|^7.0",
-                "symfony/http-client": "^5.4|^6.0|^7.0",
-                "symfony/ldap": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/rate-limiter": "^5.4|^6.0|^7.0",
-                "symfony/serializer": "^6.4|^7.0",
-                "symfony/translation": "^5.4|^6.0|^7.0",
-                "symfony/twig-bridge": "^5.4|^6.0|^7.0",
-                "symfony/twig-bundle": "^5.4|^6.0|^7.0",
-                "symfony/validator": "^6.4|^7.0",
-                "symfony/yaml": "^5.4|^6.0|^7.0",
+                "doctrine/annotations": "^1.10.4|^2",
+                "symfony/asset": "^5.4|^6.0",
+                "symfony/browser-kit": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dom-crawler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/framework-bundle": "^6.3",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/ldap": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/twig-bridge": "^5.4|^6.0",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0",
                 "twig/twig": "^2.13|^3.0.4",
                 "web-token/jwt-checker": "^3.1",
                 "web-token/jwt-signature-algorithm-ecdsa": "^3.1",
@@ -5848,7 +5839,7 @@
             "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-bundle/tree/v6.4.0"
+                "source": "https://github.com/symfony/security-bundle/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -5864,27 +5855,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-31T14:46:20+00:00"
+            "time": "2023-11-09T09:33:10+00:00"
         },
         {
             "name": "symfony/security-core",
-            "version": "v6.4.0",
+            "version": "v6.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "9e24a7199744d944c03fc1448276dc57f6237a33"
+                "reference": "7ceb30fed93f5ea40ccde3173d1f7712527c0d62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/9e24a7199744d944c03fc1448276dc57f6237a33",
-                "reference": "9e24a7199744d944c03fc1448276dc57f6237a33",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/7ceb30fed93f5ea40ccde3173d1f7712527c0d62",
+                "reference": "7ceb30fed93f5ea40ccde3173d1f7712527c0d62",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3",
-                "symfony/password-hasher": "^5.4|^6.0|^7.0",
+                "symfony/password-hasher": "^5.4|^6.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -5898,14 +5889,14 @@
                 "psr/cache": "^1.0|^2.0|^3.0",
                 "psr/container": "^1.1|^2.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^5.4|^6.0|^7.0",
-                "symfony/ldap": "^5.4|^6.0|^7.0",
-                "symfony/string": "^5.4|^6.0|^7.0",
-                "symfony/translation": "^5.4|^6.0|^7.0",
-                "symfony/validator": "^6.4|^7.0"
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/ldap": "^5.4|^6.0",
+                "symfony/string": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -5933,7 +5924,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v6.4.0"
+                "source": "https://github.com/symfony/security-core/tree/v6.3.7"
             },
             "funding": [
                 {
@@ -5949,31 +5940,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-06T17:20:05+00:00"
+            "time": "2023-10-28T23:11:45+00:00"
         },
         {
             "name": "symfony/security-csrf",
-            "version": "v6.4.0",
+            "version": "v6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-csrf.git",
-                "reference": "b28413496ebfce2f98afbb990ad0ce0ba3586638"
+                "reference": "63d7b098c448cbddb46ea5eda33b68c1ece6eb5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/b28413496ebfce2f98afbb990ad0ce0ba3586638",
-                "reference": "b28413496ebfce2f98afbb990ad0ce0ba3586638",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/63d7b098c448cbddb46ea5eda33b68c1ece6eb5b",
+                "reference": "63d7b098c448cbddb46ea5eda33b68c1ece6eb5b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "symfony/security-core": "^5.4|^6.0|^7.0"
+                "symfony/security-core": "^5.4|^6.0"
             },
             "conflict": {
                 "symfony/http-foundation": "<5.4"
             },
             "require-dev": {
-                "symfony/http-foundation": "^5.4|^6.0|^7.0"
+                "symfony/http-foundation": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -6001,7 +5992,7 @@
             "description": "Symfony Security Component - CSRF Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-csrf/tree/v6.4.0"
+                "source": "https://github.com/symfony/security-csrf/tree/v6.3.2"
             },
             "funding": [
                 {
@@ -6017,30 +6008,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-25T16:27:31+00:00"
+            "time": "2023-07-05T08:41:27+00:00"
         },
         {
             "name": "symfony/security-http",
-            "version": "v6.4.0",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "1b49ad8e9f2c3ceec011d67ac09e774e4107416b"
+                "reference": "19f7b5f5d20879a976d6d376e359bc975dfc6002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/1b49ad8e9f2c3ceec011d67ac09e774e4107416b",
-                "reference": "1b49ad8e9f2c3ceec011d67ac09e774e4107416b",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/19f7b5f5d20879a976d6d376e359bc975dfc6002",
+                "reference": "19f7b5f5d20879a976d6d376e359bc975dfc6002",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-foundation": "^6.2|^7.0",
-                "symfony/http-kernel": "^6.3|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^6.3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/property-access": "^5.4|^6.0|^7.0",
-                "symfony/security-core": "^6.4|^7.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/security-core": "^6.3",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -6052,14 +6043,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/clock": "^6.3|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/clock": "^6.3",
+                "symfony/expression-language": "^5.4|^6.0",
                 "symfony/http-client-contracts": "^3.0",
-                "symfony/rate-limiter": "^5.4|^6.0|^7.0",
-                "symfony/routing": "^5.4|^6.0|^7.0",
-                "symfony/security-csrf": "^5.4|^6.0|^7.0",
-                "symfony/translation": "^5.4|^6.0|^7.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/security-csrf": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
                 "web-token/jwt-checker": "^3.1",
                 "web-token/jwt-signature-algorithm-ecdsa": "^3.1"
             },
@@ -6089,7 +6080,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v6.4.0"
+                "source": "https://github.com/symfony/security-http/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -6105,7 +6096,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-24T21:18:21+00:00"
+            "time": "2023-11-09T21:20:12+00:00"
         },
         {
             "name": "webmozart/glob",

--- a/src/rate-limiter/composer.json
+++ b/src/rate-limiter/composer.json
@@ -17,7 +17,7 @@
         "symfony/polyfill-mbstring": "^1.0"
     },
     "require-dev": {
-        "symfony/cache": "^6.4||^7.0"
+        "symfony/cache": "^5.1||^6.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/symfony-bundle/composer.json
+++ b/src/symfony-bundle/composer.json
@@ -19,18 +19,18 @@
         "aeon-php/rate-limiter": "~1.0",
         "aeon-php/retry": "~1.0",
         "aeon-php/sleep": "~1.0",
-        "symfony/config": "^5.4.21||^6.3||^7.0",
-        "symfony/dependency-injection": "^5.4.21||^6.3||^7.0",
-        "symfony/form": "^5.4.21||^6.3||^7.0",
-        "symfony/http-kernel": "^5.4.21||^6.3||^7.0",
-        "symfony/validator": "^5.4.21||^6.3||^7.0"
+        "symfony/config": "^4.4.12||^5.0||^6.0",
+        "symfony/dependency-injection": "^4.4.12||^5.1||^6.0",
+        "symfony/form": "^4.4.12||^5.3||^6.0",
+        "symfony/http-kernel": "^4.4||^5.0||^6.0",
+        "symfony/validator": "^4.4||^5.0||^6.0"
     },
     "require-dev": {
         "aeon-php/calendar-holidays-yasumi": "~1.0",
-        "symfony/browser-kit": "^5.4.21||^6.3||^7.0",
-        "symfony/dom-crawler": "^5.4.21||^6.3||^7.0",
-        "symfony/framework-bundle": "^5.4.21||^6.3||^7.0",
-        "symfony/security-bundle": "^5.4.21||^6.3||^7.0"
+        "symfony/browser-kit": "^4.4||^5.0||^6.0",
+        "symfony/dom-crawler": "^4.4.12||^5.0||^6.0",
+        "symfony/framework-bundle": "^4.4||^5.3||^6.0",
+        "symfony/security-bundle": "^4.4||^5.0||^6.0"
     },
     "license": "MIT",
     "autoload": {

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/DependencyInjection/AeonExtension.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/DependencyInjection/AeonExtension.php
@@ -10,6 +10,7 @@ use Aeon\Calendar\TimeUnit;
 use Aeon\RateLimiter\Algorithm\LeakyBucketAlgorithm;
 use Aeon\RateLimiter\Algorithm\SlidingWindowAlgorithm;
 use Aeon\RateLimiter\RateLimiter;
+use Aeon\Symfony\AeonBundle\DependencyInjection\Loader\Configurator\LegacyConfigurator;
 use Aeon\Symfony\AeonBundle\EventListener\RateLimitExceptionListener;
 use Aeon\Symfony\AeonBundle\RateLimiter\RateLimitHttpProtocol;
 use Aeon\Symfony\AeonBundle\RateLimiter\RequestIdentificationStrategy\HeaderRequestIdentificationStrategy;
@@ -28,6 +29,9 @@ final class AeonExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container) : void
     {
+        // Trigger autoloading of legacy service function
+        \class_exists(LegacyConfigurator::class);
+
         $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/DependencyInjection/Configuration.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder() : TreeBuilder
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('aeon');
         /**

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/DependencyInjection/Loader/Configurator/LegacyConfigurator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/DependencyInjection/Loader/Configurator/LegacyConfigurator.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Symfony\AeonBundle\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator as Symfony;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+
+/**
+ * @deprecated Remove when dropping Symfony 4.4 support.
+ */
+final class LegacyConfigurator extends ContainerConfigurator
+{
+}
+
+/**
+ * @psalm-suppress UnusedParam
+ * @psalm-suppress MixedInferredReturnType
+ * @psalm-suppress MixedReturnStatement
+ */
+function service(string $id) : ReferenceConfigurator
+{
+    if (\function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service')) {
+        return Symfony\service($id);
+    }
+
+    /** @phpstan-ignore-next-line */
+    return Symfony\ref($id);
+}

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDateTimeToDateTimeTransformer.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDateTimeToDateTimeTransformer.php
@@ -13,7 +13,7 @@ final class AeonDateTimeToDateTimeTransformer implements DataTransformerInterfac
     /**
      * @psalm-suppress MissingReturnType
      */
-    public function transform($value) : mixed
+    public function transform($value)
     {
         if ($value instanceof DateTime) {
             return $value->toDateTimeImmutable();

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDayToDateTimeTransformer.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDayToDateTimeTransformer.php
@@ -13,7 +13,7 @@ final class AeonDayToDateTimeTransformer implements DataTransformerInterface
     /**
      * @psalm-suppress MissingReturnType
      */
-    public function transform($value) : mixed
+    public function transform($value)
     {
         if ($value instanceof Day) {
             return $value->toDateTimeImmutable();

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonTimeToDateTimeTransformer.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonTimeToDateTimeTransformer.php
@@ -14,7 +14,7 @@ final class AeonTimeToDateTimeTransformer implements DataTransformerInterface
     /**
      * @psalm-suppress MissingReturnType
      */
-    public function transform($value) : mixed
+    public function transform($value)
     {
         if ($value instanceof Time) {
             return new \DateTimeImmutable($value->toString());

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonTimeZoneToDateTimeTransformer.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonTimeZoneToDateTimeTransformer.php
@@ -13,7 +13,7 @@ final class AeonTimeZoneToDateTimeTransformer implements DataTransformerInterfac
     /**
      * @psalm-suppress MissingReturnType
      */
-    public function transform($value) : mixed
+    public function transform($value)
     {
         if ($value instanceof TimeZone) {
             return $value->toDateTimeZone();

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Aeon\Symfony\AeonBundle\DependencyInjection\Loader\Configurator\service;
 use Aeon\Calendar\Gregorian\Calendar;
 use Aeon\Calendar\Gregorian\GregorianCalendar;
 use Aeon\Calendar\Gregorian\TimeZone;

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Aeon\Symfony\AeonBundle\DependencyInjection\Loader\Configurator\service;
 use Aeon\Symfony\AeonBundle\Validator\Constraints\HolidayValidator;
 use Aeon\Symfony\AeonBundle\Validator\Constraints\NotHolidayValidator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_twig.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_twig.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Aeon\Symfony\AeonBundle\DependencyInjection\Loader\Configurator\service;
 use Aeon\Symfony\AeonBundle\RateLimiter\RateLimiters;
 use Aeon\Symfony\AeonBundle\Twig\RateLimiterExtension;
 use Aeon\Twig\CalendarExtension;

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_rate_limiter.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_rate_limiter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Aeon\Symfony\AeonBundle\DependencyInjection\Loader\Configurator\service;
 use Aeon\Symfony\AeonBundle\EventListener\RateLimitRequestListener;
 use Aeon\Symfony\AeonBundle\EventListener\RateLimitResponseListener;
 use Aeon\Symfony\AeonBundle\RateLimiter\RateLimiters;

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/After.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/After.php
@@ -10,29 +10,9 @@ final class After extends AbstractComparison
 {
     public const BEFORE_OR_EQUAL_ERROR = '99f63b74-a275-4a01-8678-63124971bff8';
 
-    /**
-     * @var array<string, string>
-     */
-    protected const ERROR_NAMES = [
-        self::BEFORE_OR_EQUAL_ERROR => 'BEFORE_OR_EQUAL_ERROR',
-    ];
-
-    /**
-     * @var array<string, string>
-     */
     protected static $errorNames = [
         self::BEFORE_OR_EQUAL_ERROR => 'BEFORE_OR_EQUAL_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be after {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
-    {
-        parent::__construct(
-            $value,
-            $propertyPath,
-            $message,
-            $groups,
-            $payload,
-            $options
-        );
-    }
+    public $message = 'This value should be after {{ compared_value }}.';
 }

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqual.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqual.php
@@ -10,29 +10,9 @@ final class AfterOrEqual extends AbstractComparison
 {
     public const BEFORE_ERROR = '1c6d2666-52d7-4131-bd11-3f90e2120c2d';
 
-    /**
-     * @var array<string, string>
-     */
-    protected const ERROR_NAMES = [
-        self::BEFORE_ERROR => 'BEFORE_ERROR',
-    ];
-
-    /**
-     * @var array<string, string>
-     */
     protected static $errorNames = [
         self::BEFORE_ERROR => 'BEFORE_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be after or equal {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
-    {
-        parent::__construct(
-            $value,
-            $propertyPath,
-            $message,
-            $groups,
-            $payload,
-            $options
-        );
-    }
+    public $message = 'This value should be after or equal {{ compared_value }}.';
 }

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqualValidator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqualValidator.php
@@ -14,7 +14,7 @@ final class AfterOrEqualValidator extends AbstractComparisonValidator
 {
     /**
      * @param DateTime|Day|Month|Year $value1
-     * @param null|DateTime|Day|Month|Year $value2
+     * @param ?DateTime|?Day|?Month|?Year $value2
      *
      * @return bool
      */
@@ -28,7 +28,7 @@ final class AfterOrEqualValidator extends AbstractComparisonValidator
             return false;
         }
 
-        return $value1->isAfterOrEqualTo($value2);
+        return $value1->isAfterOrEqual($value2);
     }
 
     /**

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterValidator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterValidator.php
@@ -14,7 +14,7 @@ final class AfterValidator extends AbstractComparisonValidator
 {
     /**
      * @param DateTime|Day|Month|Year $value1
-     * @param null|DateTime|Day|Month|Year $value2
+     * @param ?DateTime|?Day|?Month|?Year $value2
      *
      * @return bool
      */

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Before.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Before.php
@@ -10,29 +10,9 @@ final class Before extends AbstractComparison
 {
     public const BEFORE_OR_EQUAL_ERROR = 'c561f511-0fee-4fed-8505-6e67e21aa903';
 
-    /**
-     * @var array<string, string>
-     */
-    protected const ERROR_NAMES = [
-        self::BEFORE_OR_EQUAL_ERROR => 'BEFORE_OR_EQUAL_ERROR',
-    ];
-
-    /**
-     * @var array<string, string>
-     */
     protected static $errorNames = [
         self::BEFORE_OR_EQUAL_ERROR => 'BEFORE_OR_EQUAL_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be before {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
-    {
-        parent::__construct(
-            $value,
-            $propertyPath,
-            $message,
-            $groups,
-            $payload,
-            $options
-        );
-    }
+    public $message = 'This value should be before {{ compared_value }}.';
 }

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeOrEqual.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeOrEqual.php
@@ -10,29 +10,9 @@ final class BeforeOrEqual extends AbstractComparison
 {
     public const AFTER_ERROR = 'c411b575-c9fd-4e22-af8a-2e23a565d9a4';
 
-    /**
-     * @var array<string, string>
-     */
-    protected const ERROR_NAMES = [
-        self::AFTER_ERROR => 'AFTER_ERROR',
-    ];
-
-    /**
-     * @var array<string, string>
-     */
     protected static $errorNames = [
         self::AFTER_ERROR => 'AFTER_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be before or equal {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
-    {
-        parent::__construct(
-            $value,
-            $propertyPath,
-            $message,
-            $groups,
-            $payload,
-            $options
-        );
-    }
+    public $message = 'This value should be before or equal {{ compared_value }}.';
 }

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeOrEqualValidator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeOrEqualValidator.php
@@ -14,7 +14,7 @@ final class BeforeOrEqualValidator extends AbstractComparisonValidator
 {
     /**
      * @param DateTime|Day|Month|Year $value1
-     * @param null|DateTime|Day|Month|Year $value2
+     * @param ?DateTime|?Day|?Month|?Year $value2
      *
      * @return bool
      */
@@ -28,7 +28,7 @@ final class BeforeOrEqualValidator extends AbstractComparisonValidator
             return false;
         }
 
-        return $value1->isBeforeOrEqualTo($value2);
+        return $value1->isBeforeOrEqual($value2);
     }
 
     /**

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeValidator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeValidator.php
@@ -14,7 +14,7 @@ final class BeforeValidator extends AbstractComparisonValidator
 {
     /**
      * @param DateTime|Day|Month|Year $value1
-     * @param null|DateTime|Day|Month|Year $value2
+     * @param ?DateTime|?Day|?Month|?Year $value2
      *
      * @return bool
      */

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Equal.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Equal.php
@@ -10,29 +10,9 @@ final class Equal extends AbstractComparison
 {
     public const NOT_EQUAL_ERROR = 'c561f511-0fee-4fed-8505-6e67e21aa903';
 
-    /**
-     * @var array<string, string>
-     */
-    protected const ERROR_NAMES = [
-        self::NOT_EQUAL_ERROR => 'NOT_EQUAL_ERROR',
-    ];
-
-    /**
-     * @var array<string, string>
-     */
     protected static $errorNames = [
-        self::NOT_EQUAL_ERROR => 'NOT_EQUAL_ERROR',
+        self::NOT_EQUAL_ERROR=> 'NOT_EQUAL_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be equal {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
-    {
-        parent::__construct(
-            $value,
-            $propertyPath,
-            $message,
-            $groups,
-            $payload,
-            $options
-        );
-    }
+    public $message = 'This value should be equal {{ compared_value }}.';
 }

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/EqualValidator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/EqualValidator.php
@@ -14,13 +14,13 @@ final class EqualValidator extends AbstractComparisonValidator
 {
     /**
      * @param DateTime|Day|Month|Year $value1
-     * @param null|DateTime|Day|Month|Year $value2
+     * @param ?DateTime|?Day|?Month|?Year $value2
      *
      * @return bool
      */
     protected function compareValues($value1, $value2) : bool
     {
-        if (!$value2 instanceof DateTime && !$value2 instanceof Day && !$value2 instanceof Month && !$value2 instanceof Year) {
+        if (!$value2 instanceof DateTime && !$value2 instanceof Day && !$value2 instanceof Month  && !$value2 instanceof Year) {
             return false;
         }
 
@@ -28,7 +28,7 @@ final class EqualValidator extends AbstractComparisonValidator
             return false;
         }
 
-        return $value1->isEqualTo($value2);
+        return $value1->isEqual($value2);
     }
 
     /**

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Holiday.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Holiday.php
@@ -10,35 +10,25 @@ final class Holiday extends Constraint
 {
     public const NOT_HOLIDAY_DAY = 'a4a2fb95-c359-4683-8fbc-307967dd28a4';
 
-    /**
-     * @var array<string, string>
-     */
-    protected const ERROR_NAMES = [
-        self::NOT_HOLIDAY_DAY => 'NOT_HOLIDAY_DAY',
-    ];
-
-    /**
-     * @var array<string, string>
-     */
     protected static $errorNames = [
         self::NOT_HOLIDAY_DAY => 'NOT_HOLIDAY_DAY',
     ];
 
-    public string $message = 'Day {{ day }} is not a holiday.';
+    public $message = 'Day {{ day }} is not a holiday.';
 
-    public string $countryCode;
+    public $countryCode;
 
     public function __construct($options = null)
     {
         parent::__construct($options);
     }
 
-    public function getRequiredOptions() : array
+    public function getRequiredOptions()
     {
         return ['countryCode'];
     }
 
-    public function validatedBy() : string
+    public function validatedBy()
     {
         return 'calendar.holidays.validator.holiday';
     }

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/HolidayValidator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/HolidayValidator.php
@@ -21,7 +21,7 @@ final class HolidayValidator extends ConstraintValidator
     }
 
     /**
-     * @param mixed $value
+     * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint) : void
     {

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHoliday.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHoliday.php
@@ -10,35 +10,25 @@ final class NotHoliday extends Constraint
 {
     public const HOLIDAY_DAY = 'a4a2fb95-c359-4683-8fbc-307967dd28a4';
 
-    /**
-     * @var array<string, string>
-     */
-    protected const ERROR_NAMES = [
-        self::HOLIDAY_DAY => 'HOLIDAY_DAY',
-    ];
-
-    /**
-     * @var array<string, string>
-     */
     protected static $errorNames = [
         self::HOLIDAY_DAY => 'HOLIDAY_DAY',
     ];
 
-    public string $message = 'Day {{ day }} is a holiday.';
+    public $message = 'Day {{ day }} is a holiday.';
 
-    public string $countryCode;
+    public $countryCode;
 
     public function __construct($options = null)
     {
         parent::__construct($options);
     }
 
-    public function getRequiredOptions() : array
+    public function getRequiredOptions()
     {
         return ['countryCode'];
     }
 
-    public function validatedBy() : string
+    public function validatedBy()
     {
         return 'calendar.holidays.validator.not_holiday';
     }

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHolidayValidator.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHolidayValidator.php
@@ -21,7 +21,7 @@ final class NotHolidayValidator extends ConstraintValidator
     }
 
     /**
-     * @param mixed $value
+     * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint) : void
     {
@@ -34,6 +34,8 @@ final class NotHolidayValidator extends ConstraintValidator
         }
 
         if (!\is_string($value) && !$value instanceof Day && !$value instanceof \DateTimeInterface) {
+            \var_dump($value);
+
             throw new UnexpectedValueException($value, 'string or ' . Day::class);
         }
 


### PR DESCRIPTION
Reverts aeon-php/aeon#111 I merged it too fast, those changes put all standalone composer.json out of sync from main composer.json, seems that `./tools/vendor/bin/monorepo-builder validate` wasn't used at all. 