### PR TITLE
retry attempts fixed. Exception throwing for the retry() method unified for all cases

### DIFF
--- a/src/retry/src/Aeon/Retry/Retry.php
+++ b/src/retry/src/Aeon/Retry/Retry.php
@@ -84,19 +84,7 @@ final class Retry
          */
         $exceptions = [];
 
-        if ($this->retries === 0) {
-            $lastReturn = $function($this->lastExecution = new Execution(0));
-
-            $terminationException = $this->lastExecution->terminationException();
-
-            if ($terminationException) {
-                throw $terminationException;
-            }
-
-            return $lastReturn;
-        }
-
-        for ($retry = 0; $retry < $this->retries; $retry++) {
+        for ($retry = 0; $retry < ($this->retries + 1); $retry++) {
             try {
                 $lastReturn = $function($this->lastExecution = new Execution($retry, $exceptions));
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Num of retry attempts fixed</li>
    <li>Exception throwing condition unified</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Currently retry argument is used as total attempts counter.
when we set retry argument to 0 - 1 execution attempt will be performed (as expected)
when we set retry to 1 - still 1 execution attempt will be performed, but 2 expected (in case first attempt fails we expect it will be retried 1 time). 
same for the all other values - in fact one less retries will be performed.

In case we setup 0 retry attempts - conditions for the exception throwing will be different from case when we setup retires. It was fixed to unify behavior.
