### PR TITLE
PHP 8.4 deprecation implicitly nullable parameter

### DIFF
--- a/src/retry/src/Aeon/Retry/retry_helper.php
+++ b/src/retry/src/Aeon/Retry/retry_helper.php
@@ -17,7 +17,7 @@ use Aeon\Sleep\SystemProcess;
  *
  * @return ?FunctionReturnType
  */
-function retry(callable $function, int $retries, TimeUnit $delay, DelayModifier $delayModifier = null)
+function retry(callable $function, int $retries, TimeUnit $delay, ?DelayModifier $delayModifier = null)
 {
     return (new Retry(
         SystemProcess::current(),
@@ -40,7 +40,7 @@ function retry(callable $function, int $retries, TimeUnit $delay, DelayModifier 
  *
  * @return ?FunctionReturnType
  */
-function retryOnlyFor(callable $function, int $retries, TimeUnit $delay, array $exceptionClasses, DelayModifier $delayModifier = null)
+function retryOnlyFor(callable $function, int $retries, TimeUnit $delay, array $exceptionClasses, ?DelayModifier $delayModifier = null)
 {
     return (new Retry(
         SystemProcess::current(),

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/After.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/After.php
@@ -24,7 +24,7 @@ final class After extends AbstractComparison
         self::BEFORE_OR_EQUAL_ERROR => 'BEFORE_OR_EQUAL_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be after {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
+    public function __construct(mixed $value = null, ?string $propertyPath = null, string $message = 'This value should be after {{ compared_value }}.', ?array $groups = null, mixed $payload = null, array $options = [])
     {
         parent::__construct(
             $value,

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqual.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqual.php
@@ -24,7 +24,7 @@ final class AfterOrEqual extends AbstractComparison
         self::BEFORE_ERROR => 'BEFORE_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be after or equal {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
+    public function __construct(mixed $value = null, ?string $propertyPath = null, string $message = 'This value should be after or equal {{ compared_value }}.', ?array $groups = null, mixed $payload = null, array $options = [])
     {
         parent::__construct(
             $value,

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Before.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Before.php
@@ -24,7 +24,7 @@ final class Before extends AbstractComparison
         self::BEFORE_OR_EQUAL_ERROR => 'BEFORE_OR_EQUAL_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be before {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
+    public function __construct(mixed $value = null, ?string $propertyPath = null, string $message = 'This value should be before {{ compared_value }}.', ?array $groups = null, mixed $payload = null, array $options = [])
     {
         parent::__construct(
             $value,

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeOrEqual.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/BeforeOrEqual.php
@@ -24,7 +24,7 @@ final class BeforeOrEqual extends AbstractComparison
         self::AFTER_ERROR => 'AFTER_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be before or equal {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
+    public function __construct(mixed $value = null, ?string $propertyPath = null, string $message = 'This value should be before or equal {{ compared_value }}.', ?array $groups = null, mixed $payload = null, array $options = [])
     {
         parent::__construct(
             $value,

--- a/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Equal.php
+++ b/src/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Equal.php
@@ -24,7 +24,7 @@ final class Equal extends AbstractComparison
         self::NOT_EQUAL_ERROR => 'NOT_EQUAL_ERROR',
     ];
 
-    public function __construct(mixed $value = null, string $propertyPath = null, string $message = 'This value should be equal {{ compared_value }}.', array $groups = null, mixed $payload = null, array $options = [])
+    public function __construct(mixed $value = null, ?string $propertyPath = null, string $message = 'This value should be equal {{ compared_value }}.', ?array $groups = null, mixed $payload = null, array $options = [])
     {
         parent::__construct(
             $value,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Deprecated messages "Implicitly marking parameter type nullable is deprecated"</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

* 🔗 https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

> **Deprecated**: Aeon\Retry\retry(): Implicitly marking parameter $delayModifier as nullable is deprecated, the explicit nullable type must be used instead in **/app/vendor/aeon-php/retry/src/Aeon/Retry/retry_helper.php** on line **20**
>
> **Deprecated**: Aeon\Retry\retryOnlyFor(): Implicitly marking parameter $delayModifier as nullable is deprecated, the explicit nullable type must be used instead in **/app/vendor/aeon-php/retry/src/Aeon/Retry/retry_helper.php** on line **43**
>
> **Deprecated**: Aeon\Symfony\AeonBundle\Validator\Constraints\After::__construct(): Implicitly marking parameter $propertyPath as nullable is deprecated, the explicit nullable type must be used instead in **/app/vendor/aeon-php/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/After.php** on line **27**
>
> **Deprecated**: Aeon\Symfony\AeonBundle\Validator\Constraints\After::__construct(): Implicitly marking parameter $groups as nullable is deprecated, the explicit nullable type must be used instead in **/app/vendor/aeon-php/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/After.php** on line **27**
>
> **Deprecated**: Aeon\Symfony\AeonBundle\Validator\Constraints\AfterOrEqual::__construct(): Implicitly marking parameter $propertyPath as nullable is deprecated, the explicit nullable type must be used instead in **/app/vendor/aeon-php/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqual.php** on line **27**
>
> **Deprecated**: Aeon\Symfony\AeonBundle\Validator\Constraints\AfterOrEqual::__construct(): Implicitly marking parameter $groups as nullable is deprecated, the explicit nullable type must be used instead in **/app/vendor/aeon-php/symfony-bundle/src/Aeon/Symfony/AeonBundle/Validator/Constraints/AfterOrEqual.php** on line **27**