### PR TITLE
Add `BusinessHours::previousBusinessDay()` method

### DIFF
--- a/src/business-hours/src/Aeon/Calendar/BusinessHours/BusinessHours.php
+++ b/src/business-hours/src/Aeon/Calendar/BusinessHours/BusinessHours.php
@@ -69,8 +69,8 @@ final class BusinessHours
         $daysChecked = 0;
 
         while (
-            $this->nonBusinessDays->is($nextDay) || (!$this->regularBusinessDays->isOpenOn($nextDay)
-                && !$this->customBusinessDays->isOpenOn($nextDay))
+            $this->nonBusinessDays->is($nextDay)
+            || (!$this->regularBusinessDays->isOpenOn($nextDay) && !$this->customBusinessDays->isOpenOn($nextDay))
         ) {
             $nextDay = $nextDay->next();
             $daysChecked += 1;
@@ -81,6 +81,31 @@ final class BusinessHours
         }
 
         return $nextDay;
+    }
+
+    public function previousBusinessDay(Day $day, int $maximumDays = 365) : Day
+    {
+        if ($maximumDays <= 0) {
+            throw new InvalidArgumentException('Maximum days must be greater or equal 1');
+        }
+
+        $prevDay = $day->previous();
+
+        $daysChecked = 0;
+
+        while (
+            $this->nonBusinessDays->is($prevDay)
+            || (!$this->regularBusinessDays->isOpenOn($prevDay) && !$this->customBusinessDays->isOpenOn($prevDay))
+        ) {
+            $prevDay = $prevDay->previous();
+            $daysChecked += 1;
+
+            if ($daysChecked >= $maximumDays) {
+                throw new BusinessDayException(\sprintf('Could not find any business days in past %d days', $daysChecked));
+            }
+        }
+
+        return $prevDay;
     }
 
     public function workingHours(Day $day) : WorkingHours

--- a/src/business-hours/tests/Aeon/Calendar/Tests/Functional/BusinessHoursTest.php
+++ b/src/business-hours/tests/Aeon/Calendar/Tests/Functional/BusinessHoursTest.php
@@ -27,14 +27,14 @@ final class BusinessHoursTest extends TestCase
     {
         $regionalHolidays = new GoogleCalendarRegionalHolidays(CountryCodes::US);
 
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::mondayFriday(
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
                 new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
             ),
-            $customBusinessDays = new BusinessDays(
+            new BusinessDays(
                 new CustomBusinessDay(Day::fromString('2020-01-03'), new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm')))
             ),
-            $nonBusinessDays = new NonBusinessDays(
+            new NonBusinessDays(
                 new Holidays($regionalHolidays),
                 new NonWorkingPeriod(
                     DateTime::fromString('2020-01-02')->until(DateTime::fromString('2020-01-10'))
@@ -42,25 +42,25 @@ final class BusinessHoursTest extends TestCase
             )
         );
 
-        $this->assertFalse($businessDays->isOpenOn(Day::fromString('2020-01-01'))); // false - new year holiday
-        $this->assertFalse($businessDays->isOpenOn(Day::fromString('2020-01-02'))); // false - non business day
-        $this->assertTrue($businessDays->isOpenOn(Day::fromString('2020-01-03'))); // true  - custom business day
-        $this->assertFalse($businessDays->isOpenOn(Day::fromString('2020-01-04'))); // false - non business day
-        $this->assertFalse($businessDays->isOpenOn(Day::fromString('2020-01-11'))); // false - weekend
-        $this->assertFalse($businessDays->isOpenOn(Day::fromString('2020-01-12'))); // false - weekend
-        $this->assertTrue($businessDays->isOpenOn(Day::fromString('2020-01-13'))); // true
+        $this->assertFalse($businessHours->isOpenOn(Day::fromString('2020-01-01'))); // false - new year holiday
+        $this->assertFalse($businessHours->isOpenOn(Day::fromString('2020-01-02'))); // false - non business day
+        $this->assertTrue($businessHours->isOpenOn(Day::fromString('2020-01-03'))); // true  - custom business day
+        $this->assertFalse($businessHours->isOpenOn(Day::fromString('2020-01-04'))); // false - non business day
+        $this->assertFalse($businessHours->isOpenOn(Day::fromString('2020-01-11'))); // false - weekend
+        $this->assertFalse($businessHours->isOpenOn(Day::fromString('2020-01-12'))); // false - weekend
+        $this->assertTrue($businessHours->isOpenOn(Day::fromString('2020-01-13'))); // true
     }
 
     public function test_finding_next_working_day() : void
     {
         $regionalHolidays = new GoogleCalendarRegionalHolidays(CountryCodes::US);
 
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::mondayFriday(
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
                 new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
             ),
-            $customBusinessDays = new BusinessDays(),
-            $nonBusinessDays = new NonBusinessDays(
+            new BusinessDays(),
+            new NonBusinessDays(
                 new Holidays($regionalHolidays),
                 new NonWorkingPeriod(
                     DateTime::fromString('2020-01-02')->until(DateTime::fromString('2020-01-07'))
@@ -70,7 +70,30 @@ final class BusinessHoursTest extends TestCase
 
         $this->assertSame(
             '2020-01-07',
-            $businessDays->nextBusinessDay(Day::fromString('2020-01-04'))->format('Y-m-d')
+            $businessHours->nextBusinessDay(Day::fromString('2020-01-04'))->format('Y-m-d')
+        );
+    }
+
+    public function test_finding_previous_working_day() : void
+    {
+        $regionalHolidays = new GoogleCalendarRegionalHolidays(CountryCodes::US);
+
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
+                new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
+            ),
+            new BusinessDays(),
+            new NonBusinessDays(
+                new Holidays($regionalHolidays),
+                new NonWorkingPeriod(
+                    DateTime::fromString('2020-01-02')->until(DateTime::fromString('2020-01-07'))
+                )
+            )
+        );
+
+        $this->assertSame(
+            '2019-12-30',
+            $businessHours->previousBusinessDay(Day::fromString('2020-01-04'))->format('Y-m-d')
         );
     }
 
@@ -80,19 +103,34 @@ final class BusinessHoursTest extends TestCase
         $this->expectExceptionMessage('Could not find any business days in next 365 days');
 
         $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::none(),
-            $customBusinessDays = new BusinessDays(),
-            $nonBusinessDays = new NonBusinessDays(
+            BusinessDays::none(),
+            new BusinessDays(),
+            new NonBusinessDays(
                 new NonWorkingPeriod(
                     DateTime::fromString('2020-01-02')->until(DateTime::fromString('2020-01-07'))
                 )
             )
         );
 
-        $this->assertSame(
-            '2020-01-07',
-            $businessDays->nextBusinessDay(Day::fromString('2020-01-04'))->format('Y-m-d')
+        $businessDays->nextBusinessDay(Day::fromString('2020-01-04'))->format('Y-m-d');
+    }
+
+    public function test_finding_previous_working_day_when_business_is_permanently_closed_for_a_year() : void
+    {
+        $this->expectException(BusinessDayException::class);
+        $this->expectExceptionMessage('Could not find any business days in past 365 days');
+
+        $businessDays = new BusinessHours(
+            BusinessDays::none(),
+            new BusinessDays(),
+            new NonBusinessDays(
+                new NonWorkingPeriod(
+                    DateTime::fromString('2020-01-02')->until(DateTime::fromString('2020-01-07'))
+                )
+            )
         );
+
+        $businessDays->previousBusinessDay(Day::fromString('2020-01-04'))->format('Y-m-d');
     }
 
     public function test_finding_next_working_with_invalid_maximum_days() : void
@@ -100,43 +138,58 @@ final class BusinessHoursTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Maximum days must be greater or equal 1');
 
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::none(),
-            $customBusinessDays = new BusinessDays(),
-            $nonBusinessDays = new NonBusinessDays(
+        $businessHours = new BusinessHours(
+            BusinessDays::none(),
+            new BusinessDays(),
+            new NonBusinessDays(
                 new NonWorkingPeriod(
                     DateTime::fromString('2020-01-02')->until(DateTime::fromString('2020-01-07'))
                 )
             )
         );
 
-        $this->assertSame(
-            '2020-01-07',
-            $businessDays->nextBusinessDay(Day::fromString('2020-01-04'), 0)->format('Y-m-d')
+        $businessHours->nextBusinessDay(Day::fromString('2020-01-04'), 0)->format('Y-m-d');
+    }
+
+    public function test_finding_previous_working_with_invalid_maximum_days() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Maximum days must be greater or equal 1');
+
+        $businessHours = new BusinessHours(
+            BusinessDays::none(),
+            new BusinessDays(),
+            new NonBusinessDays(
+                new NonWorkingPeriod(
+                    DateTime::fromString('2020-01-02')->until(DateTime::fromString('2020-01-07'))
+                )
+            )
         );
+
+        $businessHours->previousBusinessDay(Day::fromString('2020-01-04'), 0)->format('Y-m-d');
     }
 
     public function test_checking_open_hours() : void
     {
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::mondayFriday(
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
                 new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
             ),
             BusinessDays::none(),
             NonBusinessDays::none(),
         );
 
-        $this->assertFalse($businessDays->isOpen(DateTime::fromString('2020-01-01 7:59am')));
-        $this->assertTrue($businessDays->isOpen(DateTime::fromString('2020-01-01 8:00am')));
-        $this->assertTrue($businessDays->isOpen(DateTime::fromString('2020-01-01 5:59pm')));
-        $this->assertTrue($businessDays->isOpen(DateTime::fromString('2020-01-01 6:00pm')));
-        $this->assertFalse($businessDays->isOpen(DateTime::fromString('2020-01-01 6:01pm')));
+        $this->assertFalse($businessHours->isOpen(DateTime::fromString('2020-01-01 7:59am')));
+        $this->assertTrue($businessHours->isOpen(DateTime::fromString('2020-01-01 8:00am')));
+        $this->assertTrue($businessHours->isOpen(DateTime::fromString('2020-01-01 5:59pm')));
+        $this->assertTrue($businessHours->isOpen(DateTime::fromString('2020-01-01 6:00pm')));
+        $this->assertFalse($businessHours->isOpen(DateTime::fromString('2020-01-01 6:01pm')));
     }
 
     public function test_checking_open_hours_for_custom_business_day() : void
     {
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::mondayFriday(
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
                 new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
             ),
             new BusinessDays(
@@ -152,17 +205,17 @@ final class BusinessHoursTest extends TestCase
             ),
         );
 
-        $this->assertFalse($businessDays->isOpen(DateTime::fromString('2020-01-02 5:59am')));
-        $this->assertTrue($businessDays->isOpen(DateTime::fromString('2020-01-02 6:00am')));
-        $this->assertTrue($businessDays->isOpen(DateTime::fromString('2020-01-02 6:00pm')));
-        $this->assertTrue($businessDays->isOpen(DateTime::fromString('2020-01-02 8:00pm')));
-        $this->assertFalse($businessDays->isOpen(DateTime::fromString('2020-01-02 8:01pm')));
+        $this->assertFalse($businessHours->isOpen(DateTime::fromString('2020-01-02 5:59am')));
+        $this->assertTrue($businessHours->isOpen(DateTime::fromString('2020-01-02 6:00am')));
+        $this->assertTrue($businessHours->isOpen(DateTime::fromString('2020-01-02 6:00pm')));
+        $this->assertTrue($businessHours->isOpen(DateTime::fromString('2020-01-02 8:00pm')));
+        $this->assertFalse($businessHours->isOpen(DateTime::fromString('2020-01-02 8:01pm')));
     }
 
     public function test_finding_next_business_day_from_holiday() : void
     {
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::mondayFriday(
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
                 new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
             ),
             BusinessDays::none(),
@@ -171,31 +224,48 @@ final class BusinessHoursTest extends TestCase
             )
         );
 
-        $this->assertSame(2, $businessDays->nextBusinessDay(Day::fromString('2020-01-01'))->number());
-        $this->assertSame(3, $businessDays->nextBusinessDay(Day::fromString('2020-01-02'))->number());
-        $this->assertSame(13, $businessDays->nextBusinessDay(Day::fromString('2020-01-11'))->number()); // saturday
+        $this->assertSame(2, $businessHours->nextBusinessDay(Day::fromString('2020-01-01'))->number());
+        $this->assertSame(3, $businessHours->nextBusinessDay(Day::fromString('2020-01-02'))->number());
+        $this->assertSame(13, $businessHours->nextBusinessDay(Day::fromString('2020-01-11'))->number()); // saturday
+    }
+
+    public function test_finding_previous_business_day_from_holiday() : void
+    {
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
+                new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
+            ),
+            BusinessDays::none(),
+            new NonBusinessDays(
+                new Holidays(new GoogleCalendarRegionalHolidays(CountryCodes::US))
+            )
+        );
+
+        $this->assertSame(30, $businessHours->previousBusinessDay(Day::fromString('2020-01-01'))->number());
+        $this->assertSame(30, $businessHours->previousBusinessDay(Day::fromString('2020-01-02'))->number());
+        $this->assertSame(10, $businessHours->previousBusinessDay(Day::fromString('2020-01-11'))->number()); // saturday
     }
 
     public function test_working_hours() : void
     {
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::mondayFriday(
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
                 new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
             ),
             BusinessDays::none(),
             NonBusinessDays::none(),
         );
 
-        $this->assertSame(8, $businessDays->workingHours(Day::fromString('2020-01-01'))->openFrom()->hour());
-        $this->assertTrue($businessDays->workingHours(Day::fromString('2020-01-01'))->openFrom()->isAM());
-        $this->assertSame(18, $businessDays->workingHours(Day::fromString('2020-01-01'))->openTo()->hour());
-        $this->assertFalse($businessDays->workingHours(Day::fromString('2020-01-01'))->openTo()->isAM());
+        $this->assertSame(8, $businessHours->workingHours(Day::fromString('2020-01-01'))->openFrom()->hour());
+        $this->assertTrue($businessHours->workingHours(Day::fromString('2020-01-01'))->openFrom()->isAM());
+        $this->assertSame(18, $businessHours->workingHours(Day::fromString('2020-01-01'))->openTo()->hour());
+        $this->assertFalse($businessHours->workingHours(Day::fromString('2020-01-01'))->openTo()->isAM());
     }
 
     public function test_working_hours_for_non_working_day() : void
     {
-        $businessDays = new BusinessHours(
-            $businessDays = BusinessDays::mondayFriday(
+        $businessHours = new BusinessHours(
+            BusinessDays::mondayFriday(
                 new LinearWorkingHours(Time::fromString('8 am'), Time::fromString('6 pm'))
             ),
             BusinessDays::none(),
@@ -207,7 +277,7 @@ final class BusinessHoursTest extends TestCase
         $this->expectException(BusinessDayException::class);
         $this->expectExceptionMessage('2020-01-01 is not a business day');
 
-        $this->assertSame(8, $businessDays->workingHours(Day::fromString('2020-01-01'))->openFrom()->hour());
+        $businessHours->workingHours(Day::fromString('2020-01-01'))->openFrom()->hour();
     }
 
     public function test_working_hours_when_non_business_or_custom_business_days_are_defined() : void
@@ -221,6 +291,6 @@ final class BusinessHoursTest extends TestCase
         $this->expectException(BusinessDayException::class);
         $this->expectExceptionMessage('2020-01-01 is not a business day');
 
-        $this->assertSame(8, $businessDays->workingHours(Day::fromString('2020-01-01'))->openFrom()->hour());
+        $businessDays->workingHours(Day::fromString('2020-01-01'))->openFrom()->hour();
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add `BusinessHours::previousBusinessDay()` method</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Allow to find the past working day, useful for calendars, crawlers, etc.
