### PR TITLE
Remove PHP 8.4 deprecations

### DIFF
--- a/src/calendar-twig/src/Aeon/Twig/CalendarExtension.php
+++ b/src/calendar-twig/src/Aeon/Twig/CalendarExtension.php
@@ -89,7 +89,7 @@ final class CalendarExtension extends AbstractExtension
      *
      * @psalm-suppress RedundantConditionGivenDocblockType
      */
-    public function aeon_datetime_create($dateTime, string $timezone = null) : DateTime
+    public function aeon_datetime_create($dateTime, ?string $timezone = null) : DateTime
     {
         if (\is_string($dateTime)) {
             $aeonDateTime = DateTime::fromString($dateTime);
@@ -112,7 +112,7 @@ final class CalendarExtension extends AbstractExtension
         return $aeonDateTime;
     }
 
-    public function aeon_datetime_format(DateTime $dateTime, string $format = null, string $timezone = null) : string
+    public function aeon_datetime_format(DateTime $dateTime, ?string $format = null, ?string $timezone = null) : string
     {
         $tz = (\is_string($timezone) && TimeZone::isValid($timezone))
             ? TimeZone::fromString($timezone)
@@ -129,7 +129,7 @@ final class CalendarExtension extends AbstractExtension
         return $dateTime->toTimeZone($this->defaultTimeZone)->format($fmt);
     }
 
-    public function aeon_time_format(Time $time, string $format = null) : string
+    public function aeon_time_format(Time $time, ?string $format = null) : string
     {
         $fmt = \is_string($format)
             ? $format
@@ -138,7 +138,7 @@ final class CalendarExtension extends AbstractExtension
         return $time->format($fmt);
     }
 
-    public function aeon_day_format(Day $day, string $format = null) : string
+    public function aeon_day_format(Day $day, ?string $format = null) : string
     {
         $fmt = \is_string($format)
             ? $format
@@ -196,7 +196,7 @@ final class CalendarExtension extends AbstractExtension
         return TimeUnit::days($days);
     }
 
-    public function aeon_now(string $timezone = null) : DateTime
+    public function aeon_now(?string $timezone = null) : DateTime
     {
         if (\is_string($timezone) && TimeZone::isValid($timezone)) {
             return $this->calendar->now()->toTimeZone(TimeZone::fromString($timezone));

--- a/src/rate-limiter/src/Aeon/RateLimiter/Exception/RateLimitException.php
+++ b/src/rate-limiter/src/Aeon/RateLimiter/Exception/RateLimitException.php
@@ -16,7 +16,7 @@ final class RateLimitException extends RuntimeException
 
     private TimeUnit $reset;
 
-    public function __construct(string $id, int $limit, TimeUnit $retryIn, TimeUnit $reset, \Throwable $previous = null)
+    public function __construct(string $id, int $limit, TimeUnit $retryIn, TimeUnit $reset, ?\Throwable $previous = null)
     {
         parent::__construct("Execution \"{$id}\" was limited for the next " . $retryIn->inSecondsPrecise() . ' seconds', 0, $previous);
 

--- a/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
+++ b/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
@@ -42,7 +42,7 @@ abstract class TestAppKernel extends BaseKernel
         return \sys_get_temp_dir() . '/AeonBundle/logs';
     }
 
-    public function holiday(Request $request, FormFactoryInterface $formFactory = null) : Response
+    public function holiday(Request $request, ?FormFactoryInterface $formFactory = null) : Response
     {
         $formFactory = $formFactory ?: $this->getContainer()->get('form.factory');
         $form = $formFactory->create(NotHolidaysFormType::class);

--- a/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AbstractComparisonValidatorTestCase.php
@@ -58,7 +58,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         yield [];
     }
 
-    abstract protected function createConstraint(array $options = null) : Constraint;
+    abstract protected function createConstraint(?array $options = null) : Constraint;
 
     protected function getErrorCode() : ?string
     {

--- a/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterOrEqualValidatorTest.php
+++ b/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterOrEqualValidatorTest.php
@@ -38,7 +38,7 @@ final class AfterOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
         return new AfterOrEqualValidator();
     }
 
-    protected function createConstraint(array $options = null) : Constraint
+    protected function createConstraint(?array $options = null) : Constraint
     {
         return new AfterOrEqual($options);
     }

--- a/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterValidatorTest.php
+++ b/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterValidatorTest.php
@@ -36,7 +36,7 @@ final class AfterValidatorTest extends AbstractComparisonValidatorTestCase
         return new AfterValidator();
     }
 
-    protected function createConstraint(array $options = null) : Constraint
+    protected function createConstraint(?array $options = null) : Constraint
     {
         return new After($options);
     }

--- a/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeOrEqualValidatorTest.php
+++ b/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeOrEqualValidatorTest.php
@@ -38,7 +38,7 @@ final class BeforeOrEqualValidatorTest extends AbstractComparisonValidatorTestCa
         return new BeforeOrEqualValidator();
     }
 
-    protected function createConstraint(array $options = null) : Constraint
+    protected function createConstraint(?array $options = null) : Constraint
     {
         return new BeforeOrEqual($options);
     }

--- a/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeValidatorTest.php
+++ b/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeValidatorTest.php
@@ -36,7 +36,7 @@ final class BeforeValidatorTest extends AbstractComparisonValidatorTestCase
         return new BeforeValidator();
     }
 
-    protected function createConstraint(array $options = null) : Constraint
+    protected function createConstraint(?array $options = null) : Constraint
     {
         return new Before($options);
     }

--- a/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/EqualValidatorTest.php
+++ b/src/symfony-bundle/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/EqualValidatorTest.php
@@ -36,7 +36,7 @@ final class EqualValidatorTest extends AbstractComparisonValidatorTestCase
         return new EqualValidator();
     }
 
-    protected function createConstraint(array $options = null) : Constraint
+    protected function createConstraint(?array $options = null) : Constraint
     {
         return new Equal($options);
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Remove PHP 8.4 deprecations</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
